### PR TITLE
Update eslint compat plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint": "^5",
     "eslint-find-rules": "^3.3.1",
     "eslint-friendly-formatter": "^4.0.1",
-    "eslint-plugin-compat": "^2.0.1",
+    "eslint-plugin-compat": "^3.1.1",
     "eslint-plugin-const-immutable": "^2.0.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "^2.30.0",


### PR DESCRIPTION
Update eslint compat plugin to warn against newer ECMAScript features.