### PR TITLE
Pin flow-typed to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-unicorn": "^15.0.1",
     "flow-bin": "^0.130.0",
     "flow-runtime": "^0.17.0",
-    "flow-typed": "^3.2.1",
+    "flow-typed": "3.2.1",
     "fs-extra": "^9.0.1",
     "hard-source-webpack-plugin": "^0.13.1",
     "imports": "^1.0.0",


### PR DESCRIPTION
The flow-typed library released [3.3.0](https://github.com/flow-typed/flow-typed/commit/6f2d272c1873b8fb1f5f3d8202f1977526b91382) today which is breaking our tooling. Pinning to 3.2.1 to resolve the issue.