### PR TITLE
Disable the autoWindowGlobal plugin for server-side tests

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -206,7 +206,7 @@ export function getWebpackConfig({
         }
         filename = `${ filename }.js`;
     }
-    
+
     vars = {
         ...vars,
         __MIN__:        minify,
@@ -234,7 +234,8 @@ export function getWebpackConfig({
 
     let plugins = [
         new webpack.DefinePlugin(jsonifyPrimitives(vars, {
-            autoWindowGlobal: test
+            // only use for client-side tests
+            autoWindowGlobal: test && web
         }))
     ];
 
@@ -276,7 +277,7 @@ export function getWebpackConfig({
             })
         ];
     }
-    
+
     if (enableCaching && !dynamic) {
         plugins = [
             ...plugins,
@@ -345,7 +346,7 @@ export function getWebpackConfig({
             extends:        babelConfig
         }
     });
-    
+
     rules.push({
         test:   /\.(html?|css|json|svg)$/,
         loader: 'raw-loader'
@@ -363,7 +364,7 @@ export function getWebpackConfig({
     if (libraryTarget) {
         output.libraryTarget = libraryTarget;
     }
-    
+
     return {
 
         context,


### PR DESCRIPTION
The server-side jest tests are currently failing since `window` is not defined with the `autoWindowGlobal` feature: https://github.com/paypal/paypal-checkout-components/pull/1607/checks?check_run_id=2336194061.

We currently pass a `web` boolean flag to webpack to indicate if its a server-side or client-side build. This PR updates the autoWindowGlobal plugin to use this `web` flag to know if its safe to use `window` or not.