### PR TITLE
Bump `@typescript-eslint/eslint-plugin` version to `^5.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/preset-react": "^7",
     "@babel/register": "^7.10.5",
     "@babel/runtime": "7.12.13",
-    "@typescript-eslint/eslint-plugin": "^4.31.2",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^4.31.2",
     "babel-eslint": "10.1.0",
     "babel-jest": "^24.9.0",


### PR DESCRIPTION
### Problem

Running `npm install` in `clientsdknodeweb` and `smartcomponentnodeweb` results in the following error:

<img width="1792" alt="Screen Shot 2021-10-25 at 10 24 44 AM" src="https://user-images.githubusercontent.com/20399044/138970104-2ba657bb-9ed5-403b-bfc0-68cd11ffdfe1.png">

### Solution

This PR bumps the version of `@typescript-eslint/eslint-plugin` to `^5.0.0` for the sole purpose of overcoming the above `npm install` error in `clientsdknodeweb`, `smartcomponentnodeweb`, and likely any other repo that has `grumbler-scripts` as a dependency.

### Testing

This was tested by changing `"@typescript-eslint/eslint-plugin": "^4.31.2"` in `grumbler-scripts`' `package.json` file to `"@typescript-eslint/eslint-plugin": "^5.0.0"`, and running `npm install`, then pointing to it locally in `clientsdknodeweb`'s `package.json` file (e.g. `"grumbler-scripts": "file:/Users/nbierdeman/Documents/grumbler-scripts"`), and running `npm install`. After it successfully completed, I confirmed that `grumbler-scripts` version `3.0.98` was installed and had `@typescript-eslint/eslint-plugin` version `5.2.0` installed.

### Concerns

Running `npm run test` in `grumbler-scripts` still passes, however, running `npm run test` in `clientsdknodeweb` now results in the following error:

![Screen Shot 2021-10-26 at 3 58 52 PM](https://user-images.githubusercontent.com/20399044/138972916-cd683df5-d450-4fe4-b312-5b966e4db753.png)