### PR TITLE
chore: bump flow-bin

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,5 +10,3 @@ declarations.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 experimental.const_params=false
-esproposal.export_star_as=enable
-esproposal.decorators=ignore

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "eslint-plugin-react": "7.20.3",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-unicorn": "^15.0.1",
-    "flow-bin": "^0.147.0",
+    "flow-bin": "^0.163.0",
     "flow-runtime": "^0.17.0",
     "flow-typed": "3.2.1",
     "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "eslint-plugin-react": "7.20.3",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-unicorn": "^15.0.1",
-    "flow-bin": "^0.163.0",
+    "flow-bin": "0.163.0",
     "flow-runtime": "^0.17.0",
     "flow-typed": "3.2.1",
     "fs-extra": "^9.0.1",


### PR DESCRIPTION
we set our flow-bin versions in the parent packages, but figured might
as well update this to latest for the typechecking inside grumbler.

Remove unused options that have been deprecated since v.0.13x.0
see for their official removal: https://github.com/facebook/flow/blob/main/Changelog.md#01500