### PR TITLE
Adding custom eslint rule for prohibiting .includes() function

### DIFF
--- a/config/.eslintrc-browser.js
+++ b/config/.eslintrc-browser.js
@@ -9,7 +9,8 @@ module.exports = {
         'promise/no-native': 'error',
         'import/no-nodejs-modules': 'error',
         'compat/compat': 'error',
-        'no-process-env': 'error'
+        'no-process-env': 'error',
+        'dont-use-includes': 'error'
     },
 
     'globals': {

--- a/config/lint-rules/dont-use-includes.js
+++ b/config/lint-rules/dont-use-includes.js
@@ -1,0 +1,17 @@
+/* @flow */
+/* eslint flowtype/require-return-type: 0, import/unambiguous: 0, import/no-commonjs: 0 */
+
+module.exports = {
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (node.callee.property && node.callee.property.name === 'includes') {
+                    context.report({
+                        node,
+                        message: 'Please, use array.indexOf() !== -1 instead of array.includes() for compatibility with IE11'
+                    });
+                }
+            }
+        };
+    }
+};

--- a/config/lint-rules/dont-use-includes.js
+++ b/config/lint-rules/dont-use-includes.js
@@ -1,5 +1,4 @@
-/* @flow */
-/* eslint flowtype/require-return-type: 0, import/unambiguous: 0, import/no-commonjs: 0 */
+/* eslint flowtype/require-valid-file-annotation: 0, flowtype/require-return-type: 0, import/unambiguous: 0, import/no-commonjs: 0 */
 
 module.exports = {
     create(context) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "setup": "npm install && npm run flow-typed",
-    "lint": "eslint --ext js,jsx config/ test/ *.js",
+    "lint": "eslint --ext js,jsx --rulesdir ./config/lint-rules config/ test/ *.js",
     "flow-typed": "flow-typed install",
     "flow": "flow",
     "flow:build": "flow gen-flow-files ./src/index.js --out-dir ./dist/module",


### PR DESCRIPTION
Creating an ESLint rule for prohibiting the function `Array.includes()` in the browser side (`.eslintrc-browser.js`).

This change is needed for compatibility with IE11 (to avoid future problems).