### PR TITLE
Ignoring resolve package in flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/node_modules/flow-runtime
 .*/node_modules/npm
 .*/node_modules/jsonlint
+.*/node_modules/resolve
 [include]
 [libs]
 flow-typed


### PR DESCRIPTION
Was trying to update babelrc to node@14, but ran into a Flow error. I saw https://github.com/paypal/paypal-card-components/pull/57, so copied it here. Issue fixed! 👍 

The tests are gewd.