### PR TITLE
Add `.mjs` extension to `eslintrc`

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
         'import/extensions': [ '.js', '.jsx' ],
         'import/resolver':   {
             'node': {
-                'extensions': [ '.js', '.jsx' ]
+                'extensions': [ '.js', '.jsx', '.mjs' ]
             }
         },
         'react': {


### PR DESCRIPTION
### Purpose

This PR adds the `.mjs` extension to the `eslintrc`. This is in preparation for using the `zx` library in `grabthar-release`: https://github.com/krakenjs/grabthar-release/pull/17